### PR TITLE
Fixed typos in reports.html

### DIFF
--- a/reports.html
+++ b/reports.html
@@ -68,8 +68,8 @@
         <h3 class="card-title">Revenue and Distributional Impacts of the American Rescue Plan Act</h3>
         <div class="row">
           <div class="col-lg-9">
-            <p class="card-text">The American Rescue Plan Act of 2021 provides over half a trillion dollars in tax benefits to Americans.  We illustrate how the Act provides substantial tax benefits to the lowest income Americans.  It also keeps a Biden campaign promise of not raising taxes on American taxpayers making less than \$400,000 per year, although some higher earning tax payers face increased tax liability due to ARPA.</p>
-            <a href="reports/QN_ARPA.pdf" class="btn btn-primary">Full Text &rarr;</a>
+            <p class="card-text">The American Rescue Plan Act of 2021 provides over half a trillion dollars in tax benefits to Americans. We illustrate how the Act provides substantial tax benefits to the lowest income Americans. It also keeps a Biden campaign promise of not raising taxes on American taxpayers making less than $400,000 per year, although some higher earning tax payers face increased tax liability due to ARPA.</p>
+            <a href="reports/QN_ARPA_Distribution.pdf" class="btn btn-primary">Full Text &rarr;</a>
           </div>
           <a class="col-lg-3 text-center" href="reports/QN_ARPA_Distribution.pdf">
             <img src="imgs/ARPA_bar_plot_by_kids.png" width=90%>


### PR DESCRIPTION
This PR fixes a typo in the abstract on the `reports.html` page as well as a link that was not updated.