### PR TITLE
Update bio page links and small content

### DIFF
--- a/experts/boyd.html
+++ b/experts/boyd.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav class="navbar fixed-top navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="imgs/logo.png" height="45"></a>
+      <a class="navbar-brand" href="../index.html"><img src="../imgs/logo.png" height="45"></a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -34,21 +34,21 @@
               About Us
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-              <a class="dropdown-item" href="index.html#about">Who we are</a>
-              <a class="dropdown-item" href="services.html">Services</a>
+              <a class="dropdown-item" href="../index.html#about">Who we are</a>
+              <a class="dropdown-item" href="../services.html">Services</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="experts.html">Experts</a>
+            <a class="nav-link" href="../experts.html">Experts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="reports.html">Reports</a>
+            <a class="nav-link" href="../reports.html">Reports</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="clients.html">Clients</a>
+            <a class="nav-link" href="../clients.html">Clients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="newsletter.html">Newsletter</a>
+            <a class="nav-link" href="../newsletter.html">Newsletter</a>
           </li>
         </ul>
       </div>

--- a/experts/boyd.html
+++ b/experts/boyd.html
@@ -63,9 +63,25 @@
           <h1>Donald Boyd</h1>
         </div>
         <p class="lead mb-5"><img src="../imgs/boyd.jpg" height=300 align="left" class="mb-4 expert-marg mr-5">
-        Donald Boyd has over three decades of experience analyzing state and local government fiscal issues. Boyd is a codirector of the State and Local Government Finance Project at the Center for Policy Research at the University at Albany’s Rockefeller College, a fellow at the Lincoln Institute of Land Policy, and a consultant to several organizations that analyze or model aspects of state and local government finances, including the Pew Charitable Trusts and the Open Source Policy Center at the American Enterprise Institute. He is the principal of Boyd Research, an economic and fiscal consulting firm, with clients that include state governments, the federal government, local governments, trade associations, labor organizations, advocacy organizations, and other groups.<br><br>
-
-        Previously, Boyd was director of fiscal studies at the Rockefeller Institute of Government, where he led the Institute’s analysis of state and local government finances in the 50 states. While at the Institute, he also developed and led its Pension Simulation Project, examining risks associated with public pension plans. His previous positions include executive director of the State Budget Crisis Task Force, which studied fiscal challenges and risks in the 50 states; director of the economic and revenue staff for the New York State Division of the Budget; and director of the tax staff for the New York State Assembly Ways and Means Committee. Boyd holds a PhD in managerial economics from Rensselaer Polytechnic Institute.</p>
+        Donald Boyd has over three decades of experience analyzing state and local government fiscal
+        issues. Boyd is a codirector of the State and Local Government Finance Project at the Center
+        for Policy Research at the University at Albany's Rockefeller College, a fellow at the Lincoln
+        Institute of Land Policy, and a consultant to several organizations that analyze or model
+        aspects of state and local government finances, including the Pew Charitable Trusts and the
+        Open Source Policy Center at the American Enterprise Institute. He is the principal of Boyd
+        Research, an economic and fiscal consulting firm, with clients that include state governments,
+        the federal government, local governments, trade associations, labor organizations, advocacy
+        organizations, and other groups.
+        <br>
+        <br>
+        Previously, Boyd was director of fiscal studies at the Rockefeller Institute of Government,
+        where he led the Institute's analysis of state and local government finances in the 50 states.
+        While at the Institute, he also developed and led its Pension Simulation Project, examining
+        risks associated with public pension plans. His previous positions include executive director
+        of the State Budget Crisis Task Force, which studied fiscal challenges and risks in the 50
+        states; director of the economic and revenue staff for the New York State Division of the
+        Budget; and director of the tax staff for the New York State Assembly Ways and Means
+        Committee. Boyd holds a PhD in managerial economics from Rensselaer Polytechnic Institute.</p>
       </div>
 
       <div class="col-lg-2 expert-border">

--- a/experts/debacker.html
+++ b/experts/debacker.html
@@ -70,9 +70,10 @@
         macroeconomics. He has published papers on these topics in the Journal of Financial Economics,
         the Journal of Law and Economics, the Journal of Public Economics, the Brookings Papers on
         Economic Activity, and other outlets. From 2009 to 2012, he worked as a financial economist
-        in the Office of Tax Analysis at the US Department of the Treasury.</p>
-
-        <p class="lead mb-5">Dr. DeBacker earned a Ph.D. in economics from the University of Texas at Austin.</p>
+        in the Office of Tax Analysis at the US Department of the Treasury.
+        <br>
+        <br>
+        Dr. DeBacker earned a Ph.D. in economics from the University of Texas at Austin.</p>
       </div>
 
       <div class="col-lg-2 expert-border">

--- a/experts/debacker.html
+++ b/experts/debacker.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav class="navbar fixed-top navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="imgs/logo.png" height="45"></a>
+      <a class="navbar-brand" href="../index.html"><img src="../imgs/logo.png" height="45"></a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -34,21 +34,21 @@
               About Us
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-              <a class="dropdown-item" href="index.html#about">Who we are</a>
-              <a class="dropdown-item" href="services.html">Services</a>
+              <a class="dropdown-item" href="../index.html#about">Who we are</a>
+              <a class="dropdown-item" href="../services.html">Services</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="experts.html">Experts</a>
+            <a class="nav-link" href="../experts.html">Experts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="reports.html">Reports</a>
+            <a class="nav-link" href="../reports.html">Reports</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="clients.html">Clients</a>
+            <a class="nav-link" href="../clients.html">Clients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="newsletter.html">Newsletter</a>
+            <a class="nav-link" href="../newsletter.html">Newsletter</a>
           </li>
         </ul>
       </div>
@@ -63,7 +63,16 @@
           <h1>Jason DeBacker</h1>
         </div>
         <p class="lead mb-5"><img src="../imgs/debacker.jpg" height=300 align="left" class="mb-4 expert-marg mr-5">
-        Jason DeBacker, Ph.D., is Vice President of Research and Co-founder of Open Research Group, Inc. (OpenRG). He is also associate professor in the Department of Economics at the Darla Moore School of Business at the University of South Carolina and Nonresident Fellow at the Tax Policy Center. His research interests lie in the areas of public finance and macroeconomics. He has published papers on these topics in the Journal of Financial Economics, the Journal of Law and Economics, the Journal of Public Economics, the Brookings Papers on Economic Activity, and other outlets. From 2009 to 2012, he worked as a financial economist in the Office of Tax Analysis at the US Department of the Treasury. Dr. DeBacker earned a Ph.D. in economics from the University of Texas at Austin.</p>
+        Jason DeBacker, Ph.D., is Vice President of Research and Co-founder of Open Research Group,
+        Inc. (OpenRG). He is also associate professor in the Department of Economics at the Darla
+        Moore School of Business at the University of South Carolina and Nonresident Fellow at the
+        Tax Policy Center. His research interests lie in the areas of public finance and
+        macroeconomics. He has published papers on these topics in the Journal of Financial Economics,
+        the Journal of Law and Economics, the Journal of Public Economics, the Brookings Papers on
+        Economic Activity, and other outlets. From 2009 to 2012, he worked as a financial economist
+        in the Office of Tax Analysis at the US Department of the Treasury.</p>
+
+        <p class="lead mb-5">Dr. DeBacker earned a Ph.D. in economics from the University of Texas at Austin.</p>
       </div>
 
       <div class="col-lg-2 expert-border">

--- a/experts/evans.html
+++ b/experts/evans.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav class="navbar fixed-top navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="imgs/logo.png" height="45"></a>
+      <a class="navbar-brand" href="../index.html"><img src="../imgs/logo.png" height="45"></a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -34,21 +34,21 @@
               About Us
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-              <a class="dropdown-item" href="index.html#about">Who we are</a>
-              <a class="dropdown-item" href="services.html">Services</a>
+              <a class="dropdown-item" href="../index.html#about">Who we are</a>
+              <a class="dropdown-item" href="../services.html">Services</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="experts.html">Experts</a>
+            <a class="nav-link" href="../experts.html">Experts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="reports.html">Reports</a>
+            <a class="nav-link" href="../reports.html">Reports</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="clients.html">Clients</a>
+            <a class="nav-link" href="../clients.html">Clients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="newsletter.html">Newsletter</a>
+            <a class="nav-link" href="../newsletter.html">Newsletter</a>
           </li>
         </ul>
       </div>

--- a/experts/evans.html
+++ b/experts/evans.html
@@ -63,7 +63,33 @@
           <h1>Richard Evans</h1>
         </div>
         <p class="lead mb-5"><img src="../imgs/evans.jpg" height=300 align="left" class="mb-4 expert-marg mr-5">
-        Richard W. Evans, Ph.D. is President and Co-founder of Open Research Group, Inc. (OpenRG). He is also Advisory Board Visiting Fellow at the Baker Institute for Public Policy at Rice University and holds appointments as Director of the Open Source Economics Laboratory, Non-resident Fellow at the Tax Policy Center of the Urban Institute and Brookings Institution, and Senior Editor at the Center for Growth and Opportunity at Utah State University. Evans specializes in macroeconomics, public economics, and computational economics. Rick was previously Associate Director and Senior Lecturer in the M.A. Program in Computational Social Science at the University of Chicago from 2016 to 2020 and a Fellow at the Becker Friedman Institute at the University of Chicago from 2016 to 2019. He was the Co-Founder and Co-Director of the BYU Macroeconomics and Computational Laboratory at Brigham Young University from 2012 to 2016. He was Assistant Professor in the BYU Economics Department from 2008 to 2016. After receiving a B.A. in economics from Brigham Young University in 1998, he began his economic career as a Research Economist at Thredgold Economic Associates in Salt Lake City, providing state and national economic analysis for Zions Bank and their operations in eight western states. Rick later received a M.A. in Public Policy from Brigham Young University in and Ph.D. in Economics from the University of Texas at Austin. He has also spent time as a researcher at the Joint Economic Committee of the U.S. Congress, the Federal Reserve Bank of Dallas, Utah Economic Council, and as an economic consultant. Rick’s current research focuses on building large-scale, open-source, dynamic general equilibrium macroeconomic models of tax policy and providing web applications and training to allow non-experts to use these models for policy analysis. Rick is a core maintainer of the <a href="https://github.com/PSLmodels/OG-USA">OG-USA</a> open source large-scale overlapping generations macroeconomic model of U.S. fiscal policy, and has provided macroeconomic modeling consulting services to the European Commission, World Bank, and Indian Ministry of Finance.</p>
+        Richard W. Evans, Ph.D. is President and Co-founder of Open Research Group, Inc. (OpenRG).
+        He is also Senior Research Fellow at the Center for Growth and Opportunity. Evans also holds
+        appointments as Senior Editor at CGO and Director of the Open Source Economics Laboratory.
+        Evans specializes in macroeconomics, public economics, and computational economics and is
+        currently leading a project at CGO to build 50 open-source state microsimulation models of
+        household tax and benefit policy as well as open access data to support those models.</p>
+
+        <p class="lead mb-5">Evans has held previous positions at the University of Chicago, Becker Friedman Institute,
+        Tax Policy Center, Rice University, and Brigham Young University. He has founded, funded, and
+        directed two major open-source and open-access student mentoring computational economics
+        research and training programs: Open Source Economics Laboratory, University of Chicago 2017-
+        2020 and BYU Macroeconomics and Computational Laboratory, Brigham Young University 2012-2016.
+        Evans has also spent time as a researcher at the Joint Economic Committee of the U.S. Congress,
+        the Federal Reserve Bank of Dallas, Utah Economic Council, and as an economic consultant.</p>
+
+        <p class="lead mb-5">Evans' research focuses on the macroeconomic effects of taxes and spending on government
+        deficits and debt, building large-scale, open-source, dynamic general equilibrium macroeconomic
+        models of tax policy, and providing web applications and training to allow non-experts to use
+        these models for policy analysis. Evans is a core maintainer of the
+        <a href="https://github.com/PSLmodels/OG-Core">OG-Core</a> open-source large-scale overlapping
+        generations macroeconomic model fiscal policy and its country-specific calibrations,
+        and has provided macroeconomic modeling consulting services to the European
+        Commission, World Bank, and Indian Ministry of Finance.</p>
+
+        <p class="lead mb-5">Evans holds a Ph.D. and M.S. in economics from the University of Texas at
+        Austin (2008, 2005), an M.A. in public policy from Brigham Young University (2003), and a B.A.
+        in economics from Brigham Young University (1998).</p>
       </div>
 
       <div class="col-lg-2 expert-border">

--- a/experts/evans.html
+++ b/experts/evans.html
@@ -68,26 +68,29 @@
         appointments as Senior Editor at CGO and Director of the Open Source Economics Laboratory.
         Evans specializes in macroeconomics, public economics, and computational economics and is
         currently leading a project at CGO to build 50 open-source state microsimulation models of
-        household tax and benefit policy as well as open access data to support those models.</p>
-
-        <p class="lead mb-5">Evans has held previous positions at the University of Chicago, Becker Friedman Institute,
+        household tax and benefit policy as well as open access data to support those models.
+        <br>
+        <br>
+        Evans has held previous positions at the University of Chicago, Becker Friedman Institute,
         Tax Policy Center, Rice University, and Brigham Young University. He has founded, funded, and
         directed two major open-source and open-access student mentoring computational economics
         research and training programs: Open Source Economics Laboratory, University of Chicago 2017-
         2020 and BYU Macroeconomics and Computational Laboratory, Brigham Young University 2012-2016.
         Evans has also spent time as a researcher at the Joint Economic Committee of the U.S. Congress,
-        the Federal Reserve Bank of Dallas, Utah Economic Council, and as an economic consultant.</p>
-
-        <p class="lead mb-5">Evans' research focuses on the macroeconomic effects of taxes and spending on government
+        the Federal Reserve Bank of Dallas, Utah Economic Council, and as an economic consultant.
+        <br>
+        <br>
+        Evans' research focuses on the macroeconomic effects of taxes and spending on government
         deficits and debt, building large-scale, open-source, dynamic general equilibrium macroeconomic
         models of tax policy, and providing web applications and training to allow non-experts to use
         these models for policy analysis. Evans is a core maintainer of the
         <a href="https://github.com/PSLmodels/OG-Core">OG-Core</a> open-source large-scale overlapping
         generations macroeconomic model fiscal policy and its country-specific calibrations,
         and has provided macroeconomic modeling consulting services to the European
-        Commission, World Bank, and Indian Ministry of Finance.</p>
-
-        <p class="lead mb-5">Evans holds a Ph.D. and M.S. in economics from the University of Texas at
+        Commission, World Bank, and Indian Ministry of Finance.
+        <br>
+        <br>
+        Evans holds a Ph.D. and M.S. in economics from the University of Texas at
         Austin (2008, 2005), an M.A. in public policy from Brigham Young University (2003), and a B.A.
         in economics from Brigham Young University (1998).</p>
       </div>

--- a/experts/frailey.html
+++ b/experts/frailey.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav class="navbar fixed-top navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="imgs/logo.png" height="45"></a>
+      <a class="navbar-brand" href="../index.html"><img src="../imgs/logo.png" height="45"></a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -34,21 +34,21 @@
               About Us
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-              <a class="dropdown-item" href="index.html#about">Who we are</a>
-              <a class="dropdown-item" href="services.html">Services</a>
+              <a class="dropdown-item" href="../index.html#about">Who we are</a>
+              <a class="dropdown-item" href="../services.html">Services</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="experts.html">Experts</a>
+            <a class="nav-link" href="../experts.html">Experts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="reports.html">Reports</a>
+            <a class="nav-link" href="../reports.html">Reports</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="clients.html">Clients</a>
+            <a class="nav-link" href="../clients.html">Clients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="newsletter.html">Newsletter</a>
+            <a class="nav-link" href="../newsletter.html">Newsletter</a>
           </li>
         </ul>
       </div>
@@ -63,7 +63,15 @@
           <h1>Anderson Frailey</h1>
         </div>
         <p class="lead mb-5"><img src="../imgs/frailey.jpg" height=300 align="left" class="mb-4 expert-marg mr-5">
-          Anderson Frailey is a PhD student in the Department of Economics at the University of Virginia. He has made substantial contributions to open-source economic modeling projects including <a href="https://github.com/PSLmodels/taxdata">TaxData</a> and <a href="https://github.com/PSLmodels/Tax-Calculator">Tax-Calculator</a>. Mr. Frailey has previously worked as a consultant for the World Bank, assisting India's Ministry of Finance in developing a microsimulation tax model, and as a research associate in the Open Source Policy Center at the American Enterprise Institute. His areas of research include tax policy and universal basic income. Mr. Frailey received a bachelor's degree in economics from the University of Texas at Austin.</p>
+        Anderson Frailey is a Ph.D. student in the Department of Economics at the University of
+        Virginia. He has made substantial contributions to open-source economic modeling projects
+        including <a href="https://github.com/PSLmodels/taxdata">TaxData</a> and
+        <a href="https://github.com/PSLmodels/Tax-Calculator">Tax-Calculator</a>. Frailey has
+        previously worked as a consultant for the World Bank, assisting India's Ministry of Finance
+        in developing a microsimulation tax model, and as a research associate in the Open Source
+        Policy Center at the American Enterprise Institute. His areas of research include tax policy
+        and universal basic income. Frailey received a bachelor's degree in economics from the
+        University of Texas at Austin.</p>
       </div>
 
       <div class="col-lg-2 expert-border">

--- a/experts/ghenis.html
+++ b/experts/ghenis.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav class="navbar fixed-top navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="imgs/logo.png" height="45"></a>
+      <a class="navbar-brand" href="../index.html"><img src="../imgs/logo.png" height="45"></a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -34,21 +34,21 @@
               About Us
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-              <a class="dropdown-item" href="index.html#about">Who we are</a>
-              <a class="dropdown-item" href="services.html">Services</a>
+              <a class="dropdown-item" href="../index.html#about">Who we are</a>
+              <a class="dropdown-item" href="../services.html">Services</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="experts.html">Experts</a>
+            <a class="nav-link" href="../experts.html">Experts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="reports.html">Reports</a>
+            <a class="nav-link" href="../reports.html">Reports</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="clients.html">Clients</a>
+            <a class="nav-link" href="../clients.html">Clients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="newsletter.html">Newsletter</a>
+            <a class="nav-link" href="../newsletter.html">Newsletter</a>
           </li>
         </ul>
       </div>
@@ -63,8 +63,16 @@
           <h1>Max Ghenis</h1>
         </div>
         <p class="lead mb-5"><img src="../imgs/ghenis.jpg" height=300 align="left" class="mb-4 expert-marg mr-5">
-        <p><span style="font-weight: 400;">Max Ghenis is the founder and president of the </span><a href="https://www.ubicenter.org/"><span style="font-weight: 400;">UBI Center</span></a><span style="font-weight: 400;">, an open source think tank researching universal basic income policies. Prior to the UBI Center, he was a data scientist at Google. Max has a master’s degree in Data, Economics, and Development Policy from the Massachusetts Institute of Technology and a bachelor’s degree in operations research from the University of California at Berkeley.</span></p>
-        <p><span style="font-weight: 400;">Max is a core maintainer of the </span><a href="https://github.com/PSLmodels/microdf"><span style="font-weight: 400;">microdf</span></a><span style="font-weight: 400;"> open source Python package of analysis tools for working with survey microdata as DataFrames.</span></p> </div>
+        Max Ghenis is the founder and president of <a href="https://policyengine.org/">Policy Engine</a>
+        and of the <a href="https://www.ubicenter.org/">UBI Center</a>, an open source think tank
+        researching universal basic income policies. Prior to the UBI Center, he was a data scientist
+        at Google. Max has a master's degree in Data, Economics, and Development Policy from the
+        Massachusetts Institute of Technology and a bachelors degree in operations research from the
+        University of California at Berkeley.</p>
+
+        <p class="lead mb-5">Max is a core maintainer of the
+        <a href="https://github.com/PSLmodels/microdf">microdf</a> open source Python package of
+        analysis tools for working with survey microdata as DataFrames.</p> </div>
 
       <div class="col-lg-2 expert-border">
         <div class="mt-4 mb-4">

--- a/experts/ghenis.html
+++ b/experts/ghenis.html
@@ -68,11 +68,12 @@
         researching universal basic income policies. Prior to the UBI Center, he was a data scientist
         at Google. Max has a master's degree in Data, Economics, and Development Policy from the
         Massachusetts Institute of Technology and a bachelors degree in operations research from the
-        University of California at Berkeley.</p>
-
-        <p class="lead mb-5">Max is a core maintainer of the
-        <a href="https://github.com/PSLmodels/microdf">microdf</a> open source Python package of
-        analysis tools for working with survey microdata as DataFrames.</p> </div>
+        University of California at Berkeley.
+        <br>
+        <br>
+        Max is a core maintainer of the <a href="https://github.com/PSLmodels/microdf">microdf</a>
+        open source Python package of analysis tools for working with survey microdata as
+        DataFrames.</p> </div>
 
       <div class="col-lg-2 expert-border">
         <div class="mt-4 mb-4">

--- a/experts/jensen.html
+++ b/experts/jensen.html
@@ -69,16 +69,18 @@
         projects, including <a href="https://pslmodels.github.io/Tax-Calculator/">Tax-Calculator</a>,
         and the <a href="http://pslmodels.org">Policy Simulation Library</a>. Jensen is the co-founder
         of Compute Tooling, Inc. and the <a href="https://about.compute.studio/">Compute Studio</a>
-        computational modeling platform.</p>
-
-        <p class="lead mb-5">The primary goal of Jensen's activity is to improve the performance of
+        computational modeling platform.
+        <br>
+        <br>
+        The primary goal of Jensen's activity is to improve the performance of
         democratic governments and other organizations in developing and developed countries by
         supporting leadership and decision making with technology. At times, Jensen advises
         policymakers and campaigns on economic and technology policy. Jensen's work has been featured
         in the <em>Wall Street Journal</em>, the <em>New York Times</em>, the <em>Washington Post</em>,
-        CNN, Fox News, MSNBC, and many other publications.</p>
-
-        <p class="lead mb-5">Jensen is a graduate of Pomona College with a degree in math. He grew up
+        CNN, Fox News, MSNBC, and many other publications.
+        <br>
+        <br>
+        Jensen is a graduate of Pomona College with a degree in math. He grew up
         in Indiana, keeps an office in Washington, D.C., and lives in New Jersey with his family.</p> </div>
 
       <div class="col-lg-2 expert-border">

--- a/experts/jensen.html
+++ b/experts/jensen.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav class="navbar fixed-top navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="imgs/logo.png" height="45"></a>
+      <a class="navbar-brand" href="../index.html"><img src="../imgs/logo.png" height="45"></a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -34,21 +34,21 @@
               About Us
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-              <a class="dropdown-item" href="index.html#about">Who we are</a>
-              <a class="dropdown-item" href="services.html">Services</a>
+              <a class="dropdown-item" href="../index.html#about">Who we are</a>
+              <a class="dropdown-item" href="../services.html">Services</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="experts.html">Experts</a>
+            <a class="nav-link" href="../experts.html">Experts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="reports.html">Reports</a>
+            <a class="nav-link" href="../reports.html">Reports</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="clients.html">Clients</a>
+            <a class="nav-link" href="../clients.html">Clients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="newsletter.html">Newsletter</a>
+            <a class="nav-link" href="../newsletter.html">Newsletter</a>
           </li>
         </ul>
       </div>
@@ -63,9 +63,23 @@
           <h1>Matt Jensen</h1>
         </div>
         <p class="lead mb-5"><img src="../imgs/jensen.jpg" height=300 align="left" class="mb-4 expert-marg mr-5">
-        <p><span style="font-weight: 400;">Matt Jensen is Principal and Co-founder of Open Research Group, Inc. (OpenRG). He is also director of the </span><a href="http://ospc.org"><span style="font-weight: 400;">Open Source Policy Center</span></a><span style="font-weight: 400;"> at the </span><a href="http://aei.org"><span style="font-weight: 400;">American Enterprise Institute</span></a><span style="font-weight: 400;">. He is also the co-creator of several widely-used open source projects, including </span><a href="https://pslmodels.github.io/Tax-Calculator/"><span style="font-weight: 400;">Tax-Calculator</span></a><span style="font-weight: 400;">, the </span><a href="http://pslmodels.org"><span style="font-weight: 400;">Policy Simulation Library</span></a><span style="font-weight: 400;">, and the </span><a href="http://compmodels.org"><span style="font-weight: 400;">Computational Modeling Platform</span></a><span style="font-weight: 400;">. Jensen is the co-founder of Compute Tooling, Inc. and the </span><a href="http://openrg.com"><span style="font-weight: 400;">Open Research Group, Inc.</span></a><span style="font-weight: 400;">.</span></p>
-        <p><span style="font-weight: 400;">The primary goal of Jensen&rsquo;s activity is to improve the performance of democratic governments and other organizations in developing and developed countries by supporting leadership and decision-making with technology. At times, Jensen advises policymakers and campaigns on economic and technology policy. Jensen&rsquo;s work has been featured in the <em>Wall Street Journal</em>, the <em>New York Times</em>, the <em>Washington Post</em>, CNN, Fox News, MSNBC, and&nbsp; many other publications.</span></p>
-        <p><span style="font-weight: 400;">Jensen is a graduate of Pomona College with a degree in math. He grew up in Indiana, keeps an office in Washington, D.C., and lives in New Jersey with his family. </span></p> </div>
+        Matt Jensen is Principal and Co-founder of Open Research Group, Inc. (OpenRG). Jensen was the
+        founder and director of the <a href="http://ospc.org">Open Source Policy Center</a> at the
+        American Enterprise Institute. He is also the co-creator of several widely-used open source
+        projects, including <a href="https://pslmodels.github.io/Tax-Calculator/">Tax-Calculator</a>,
+        and the <a href="http://pslmodels.org">Policy Simulation Library</a>. Jensen is the co-founder
+        of Compute Tooling, Inc. and the <a href="https://about.compute.studio/">Compute Studio</a>
+        computational modeling platform.</p>
+
+        <p class="lead mb-5">The primary goal of Jensen's activity is to improve the performance of
+        democratic governments and other organizations in developing and developed countries by
+        supporting leadership and decision making with technology. At times, Jensen advises
+        policymakers and campaigns on economic and technology policy. Jensen's work has been featured
+        in the <em>Wall Street Journal</em>, the <em>New York Times</em>, the <em>Washington Post</em>,
+        CNN, Fox News, MSNBC, and many other publications.</p>
+
+        <p class="lead mb-5">Jensen is a graduate of Pomona College with a degree in math. He grew up
+        in Indiana, keeps an office in Washington, D.C., and lives in New Jersey with his family.</p> </div>
 
       <div class="col-lg-2 expert-border">
         <div class="mt-4 mb-4">

--- a/experts/pycroft.html
+++ b/experts/pycroft.html
@@ -70,9 +70,10 @@
         tax, he was responsible for using the CORTAX computable general equilibrium model to estimate
         the macroeconomic impacts of EU-wide tax reform proposals. He co-developed of the
         micro-macro dynamic model EDGE-M3, the EC's in-house overlapping generations model for public
-        policy analysis, which is linked to the EUROMOD microsimulation model.</p>
-
-        <p class="lead mb-5">Jonathan has also worked on climate change economics, modelling issues
+        policy analysis, which is linked to the EUROMOD microsimulation model.
+        <br>
+        <br>
+        Jonathan has also worked on climate change economics, modelling issues
         such as the emissions trading scheme (ETS), the potential economic damages from sea-level
         rise and the social cost of carbon dioxide. Earlier in his career he worked extensively in
         sub-Saharan Africa on issues ranging from foreign aid and trade to agriculture and health,

--- a/experts/pycroft.html
+++ b/experts/pycroft.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav class="navbar fixed-top navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="imgs/logo.png" height="45"></a>
+      <a class="navbar-brand" href="../index.html"><img src="../imgs/logo.png" height="45"></a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -34,21 +34,21 @@
               About Us
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-              <a class="dropdown-item" href="index.html#about">Who we are</a>
-              <a class="dropdown-item" href="services.html">Services</a>
+              <a class="dropdown-item" href="../index.html#about">Who we are</a>
+              <a class="dropdown-item" href="../services.html">Services</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="experts.html">Experts</a>
+            <a class="nav-link" href="../experts.html">Experts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="reports.html">Reports</a>
+            <a class="nav-link" href="../reports.html">Reports</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="clients.html">Clients</a>
+            <a class="nav-link" href="../clients.html">Clients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="newsletter.html">Newsletter</a>
+            <a class="nav-link" href="../newsletter.html">Newsletter</a>
           </li>
         </ul>
       </div>
@@ -63,10 +63,23 @@
           <h1>Jonathan Pycroft</h1>
         </div>
         <p class="lead mb-5"><img src="../imgs/pycroft.jpg" height=300 align="left" class="mb-4 expert-marg mr-5">
-        Jonathan Pycroft, Ph.D., is an economic modeller with extensive experience in fiscal policy. He worked for the European Commission for nine years, helping to build the Fiscal Policy Analysis Unit (JRC-Seville). During this time, he developed the use of the EUROMOD microsimulation model, co-creating the EUROMOD-JRC Web Interface. In the field of corporate tax, he was responsible for using the CORTAX computable general equilibrium model to estimate the macroeconomic impacts of EU-wide tax reform proposals. He co-developed of the micro-macro dynamic model EDGE-M3, the EC’s in-house overlapping generations model for public policy analysis, which is linked to the EUROMOD microsimulation model.
-        <br><br>
-        Jonathan has also worked on climate change economics, modelling issues such as the emissions trading scheme (ETS), the potential economic damages from sea-level rise and the social cost of carbon dioxide. Earlier in his career he worked extensively in sub-Saharan Africa on issues ranging from foreign aid and trade to agriculture and health, utilising econometric analysis and computable general equilibrium (CGE) modelling.
-        He has advised national governments and international organisations, including the World Bank and the United Nations, and has published in various academic journals. He holds degrees in economics from the Universities of Warwick (BSc.), Oxford (MSc.) and Sussex (DPhil).</p>
+        Jonathan Pycroft, Ph.D., is an economic modeller with extensive experience in fiscal policy.
+        He worked for the European Commission for nine years, helping to build the Fiscal Policy
+        Analysis Unit (JRC-Seville). During this time, he developed the use of the EUROMOD
+        microsimulation model, co-creating the EUROMOD-JRC Web Interface. In the field of corporate
+        tax, he was responsible for using the CORTAX computable general equilibrium model to estimate
+        the macroeconomic impacts of EU-wide tax reform proposals. He co-developed of the
+        micro-macro dynamic model EDGE-M3, the EC's in-house overlapping generations model for public
+        policy analysis, which is linked to the EUROMOD microsimulation model.</p>
+
+        <p class="lead mb-5">Jonathan has also worked on climate change economics, modelling issues
+        such as the emissions trading scheme (ETS), the potential economic damages from sea-level
+        rise and the social cost of carbon dioxide. Earlier in his career he worked extensively in
+        sub-Saharan Africa on issues ranging from foreign aid and trade to agriculture and health,
+        utilising econometric analysis and computable general equilibrium (CGE) modelling. He has
+        advised national governments and international organisations, including the World Bank and
+        the United Nations, and has published in various academic journals. He holds degrees in
+        economics from the Universities of Warwick (BSc.), Oxford (MSc.) and Sussex (DPhil).</p>
       </div>
 
       <div class="col-lg-2 expert-border">

--- a/experts/zhong.html
+++ b/experts/zhong.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav class="navbar fixed-top navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="imgs/logo.png" height="45"></a>
+      <a class="navbar-brand" href="../index.html"><img src="../imgs/logo.png" height="45"></a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -34,21 +34,21 @@
               About Us
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownBlog">
-              <a class="dropdown-item" href="index.html#about">Who we are</a>
-              <a class="dropdown-item" href="services.html">Services</a>
+              <a class="dropdown-item" href="../index.html#about">Who we are</a>
+              <a class="dropdown-item" href="../services.html">Services</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="experts.html">Experts</a>
+            <a class="nav-link" href="../experts.html">Experts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="reports.html">Reports</a>
+            <a class="nav-link" href="../reports.html">Reports</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="clients.html">Clients</a>
+            <a class="nav-link" href="../clients.html">Clients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="newsletter.html">Newsletter</a>
+            <a class="nav-link" href="../newsletter.html">Newsletter</a>
           </li>
         </ul>
       </div>
@@ -63,13 +63,31 @@
           <h1>Weifeng Zhong</h1>
         </div>
         <p class="lead mb-5"><img src="../imgs/zhong.jpg" height=300 align="left" class="mb-4 expert-marg mr-5">
-        Weifeng Zhong, Ph.D., is a Senior Research Fellow at the Mercatus Center at George Mason University. His work focuses on bridging the field of natural language processing and machine learning to economic policy studies. His other research interests include political economy, US-China economic relations, and China's economic issues.<br><br>
-
-        Dr. Zhong is a core maintainer of the open-source Policy Change Index (PCI) project, a framework that uses machine learning to "read" large volumes of text and detect subtle, structural changes embedded in it. As a first use case, the PCI for China is an algorithm that can predict China's policy changes using the information in the government’s official newspaper. The PCI framework has received significant academic interest and media coverage. The resources of this project are freely available at policychangeindex.org.<br><br>
-
-        Dr. Zhong has been published in a variety of scholarly journals, including the Journal of Institutional and Theoretical Economics. His research and writings have been featured in the Financial Times, Foreign Affairs, The National Interest, Real Clear Markets, Real Clear Politics, the South China Morning Post, and The Wall Street Journal, among others.<br><br>
-
-        Previously, Dr. Zhong has been a research fellow at the American Enterprise Institute. He has a Ph.D. and an M.Sc. in managerial economics and strategy from Northwestern University. He also holds M.Econ. and M.Phil. degrees in economics from the University of Hong Kong and a B.A. in business administration from Shantou University in China.</p>
+        Weifeng Zhong, Ph.D., is a Senior Research Fellow at the Mercatus Center at George Mason
+        University. His work focuses on bridging the field of natural language processing and machine
+        learning to economic policy studies. His other research interests include political economy,
+        US-China economic relations, and China's economic issues.
+        <br>
+        <br>
+        Dr. Zhong is a core maintainer of the open-source Policy Change Index (PCI) project, a
+        framework that uses machine learning to "read" large volumes of text and detect subtle,
+        structural changes embedded in it. As a first use case, the PCI for China is an algorithm
+        that can predict China's policy changes using the information in the government's official
+        newspaper. The PCI framework has received significant academic interest and media coverage.
+        The resources of this project are freely available at policychangeindex.org.
+        <br>
+        <br>
+        Dr. Zhong has been published in a variety of scholarly journals, including the
+        <em>Journal of Institutional and Theoretical Economics</em>. His research and writings have
+        been featured in the <em>Financial Times</em>, <em>Foreign Affairs</em>,
+        <em>The National Interest</em>, Real Clear Markets, Real Clear Politics, the
+        <em>South China Morning Post</em>, and <em>The Wall Street Journal</em>, among others.
+        <br>
+        <br>
+        Previously, Dr. Zhong has been a research fellow at the American Enterprise Institute. He
+        has a Ph.D. and an M.Sc. in managerial economics and strategy from Northwestern University.
+        He also holds M.Econ. and M.Phil. degrees in economics from the University of Hong Kong
+        and a B.A. in business administration from Shantou University in China.</p>
       </div>
 
       <div class="col-lg-2 expert-border">


### PR DESCRIPTION
This PR does the following with the expert bios:
* The top links and OpenRG image were all broken on all the expert pages (see current version of [https://www.openrg.com/experts/evans.html](https://www.openrg.com/experts/evans.html)). This PR fixes all those links in each of the pages.
* I adjusted the formatting in a few of the expert pages by standardizing paragraph breaks, font sizes, and hyperlinks.
* I updated Evans' bio, and made some small updates to Jensen's and Ghenis' respective bios.

cc: @jdebacker @MattHJensen 